### PR TITLE
fix a bug around enqueueing tasks during shutdown

### DIFF
--- a/thimble/test/util.py
+++ b/thimble/test/util.py
@@ -15,14 +15,16 @@ class FakeThreadPool(object):
         """Initialize the fake thread pool."""
         self.started = False
         self.success = True
+        self.joined = False
 
     def start(self):
         """Set the ``started`` attribute to ``True``."""
         self.started = True
 
     def stop(self):
-        """Set the ``started`` attribute to ``True``."""
+        """Set the ``started`` attribute to ``False``."""
         self.started = False
+        self.joined = True
 
     def callInThreadWithCallback(self, onResult, f, *args, **kwargs):
         """Evaluate ``f(*args, **kwargs)`` and calls ``onResult``.

--- a/thimble/wrapper.py
+++ b/thimble/wrapper.py
@@ -34,7 +34,7 @@ class Thimble(object):
         exception.
 
         """
-        if not self._pool.started:
+        if (not self._pool.started) and (not self._pool.joined):
             self._pool.start()
             self._reactor.addSystemEventTrigger(
                 'before', 'shutdown', self._pool.stop)

--- a/thimble/wrapper.py
+++ b/thimble/wrapper.py
@@ -1,6 +1,8 @@
 """Implementation of a Twisted-friendly thread pool wrapper."""
 from functools import partial
 from twisted.internet.threads import deferToThreadPool
+from twisted.internet.defer import fail
+from twisted.internet.error import ReactorNotRunning
 
 
 class Thimble(object):
@@ -34,10 +36,14 @@ class Thimble(object):
         exception.
 
         """
-        if (not self._pool.started) and (not self._pool.joined):
+        if self._pool.joined:
+            return fail(
+                ReactorNotRunning("This thimble's threadpool already stopped.")
+            )
+        if not self._pool.started:
             self._pool.start()
             self._reactor.addSystemEventTrigger(
-                'before', 'shutdown', self._pool.stop)
+                'during', 'shutdown', self._pool.stop)
 
         return deferToThreadPool(self._reactor, self._pool, f, *args, **kwargs)
 


### PR DESCRIPTION
The `started` flag on `ThreadPool` is poorly named and has surprising semantics; it actually means "currently running", and is set to `False` during shutdown.  However, there's another flag you can check, `joined`, which indicates whether the main thread is currently trying to `join()` all its threads; in other words, "has stop been called".

More recent versions of Twisted will actually report this error as an `AlreadyQuitError` exception coming out of `twisted._threads`.